### PR TITLE
include gh actions deploy guide on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,9 @@ Cloudflare's [edge infrastructure](https://www.cloudflare.com/network/).
 6. [Add bot permissions](https://discord.com/developers/docs/tutorials/hosting-on-cloudflare-workers#adding-bot-permissions) and grab your Oauth url to invite the bot to your server
 7. Publish the demo app with `wrangler publish`. The template bot contains a single hello command with a dummy autocomplete argument.
 8. Put your bot domain `https://bot.<mydomain>.workers.dev` in the `INTERACTIONS ENDPOINT URL` in your discord app page from step 4
-9. After initial deployment and each time you add a new command on your bot you need to register it with the discord api. To do that simply `curl -X POST http://bot.<mydomain>.workers.dev/register`
+9. After initial deployment and each time you add a new command on your bot you need to register it with the discord api. To do that simply `curl -X POST https://bot.<mydomain>.workers.dev/register`
 
-You should now be able to run the `/hello` command on discord 
-
+You should now be able to run the `/hello` command on discord
 
 ## Adding new commands
 
@@ -66,7 +65,7 @@ impl Command for Ping {
     async fn autocomplete(&self, _input: &CommandInput) -> Result<Option<InteractionApplicationCommandCallbackData>, InteractionError> {
         None
     }
-
+}
 ```
 2. add your new module in src/commands/mod.rs
 3. Register your command in  `init_commands` in src/command.rs 
@@ -107,6 +106,37 @@ wrangler publish
 ```
 
 you can use `ngrok` to tunnel traffic into your local machine, more info [here](https://discord.com/developers/docs/tutorials/hosting-on-cloudflare-workers#setting-up-ngrok)
+
+## Actions Deployments
+
+You can create an a action to automatically deploy your worker & register your commands on each push to main.
+
+Create a repository secret with your `CF_API_TOKEN` and add the following to your workflow file:
+
+``` yaml
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout Repository
+            - uses: actions/checkout@v3
+
+            - name: Deploy to Cloudflare Workers
+              env:
+                  CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+              run: npm i -g wrangler && npx wrangler publish
+
+            - name: Curl the worker
+              run: curl -X POST https://<your_worker_domain>/register
+```
+
 
 ## WebAssembly
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ you can use `ngrok` to tunnel traffic into your local machine, more info [here](
 
 You can create an a action to automatically deploy your worker & register your commands on each push to main.
 
-Create a repository secret with your `CF_API_TOKEN` and add the following to your workflow file:
+Create a Cloudflare API token and use the `Edit Cloudflare Workers` template.
+
+Then, create a repository secret with your API Token under `CF_API_TOKEN` and add the following inside `.github/workflows/deploy.yml`:
 
 ``` yaml
 name: Deploy to Cloudflare Workers


### PR DESCRIPTION
Thank you for creating this repository, just a few things I wanted to add:

Instead of having to manually curl & publish each time - you can easily create an action to do this for you. However, `@cloudflare/wrangler-action` does not support rust therefore there is a pretty easy workaround you can do that isn't documented anywhere on their repo (as a workaround).

Felt as if adding instructions on how to setup deployments (& curl `/register`) w/ GitHub actions may be useful to some, also added a missing `}` in your ping example & fixed the curl url.